### PR TITLE
Pin version of trx-to-vsplaylist tool

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
       shell: bash
       run: |
         echo "Installing trx-to-vsplaylist tool..."
-        dotnet tool install --global trx-to-vsplaylist
+        dotnet tool install --global trx-to-vsplaylist --version 1.1.0
         echo "✅ trx-to-vsplaylist tool installed successfully"
 
     - name: Convert TRX to Playlist


### PR DESCRIPTION
Specifies the version of the trx-to-vsplaylist tool to be installed.

This ensures consistency and prevents unexpected behavior
due to automatic updates to newer versions of the tool.
